### PR TITLE
chore: add dcl password provider role

### DIFF
--- a/roles/matrix-base/tasks/setup_matrix_base.yml
+++ b/roles/matrix-base/tasks/setup_matrix_base.yml
@@ -19,15 +19,6 @@
     mode: '0660'
   when: "matrix_vars_yml_snapshotting_enabled|bool"
 
-- name: Preserve decentraland password auth provider on the server for easily restoring if it gets lost later on
-  copy:
-    src: "{{ matrix_decentraland_passwords_file_src }}"
-    dest: "{{ matrix_base_data_path }}/decentraland_password_auth_provider.py"
-    owner: "{{ matrix_user_username }}"
-    group: "{{ matrix_user_groupname }}"
-    mode: '0660'
-  when: "use_decentraland_password_provider|bool"
-
 - name: Ensure Matrix network is created in Docker
   docker_network:
     name: "{{ matrix_docker_network }}"

--- a/roles/matrix-dcl-password-provider/tasks/main.yml
+++ b/roles/matrix-dcl-password-provider/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- import_tasks: "{{ role_path }}/tasks/setup_install.yml"
+  when: "use_decentraland_password_provider|bool"
+  tags:
+  - setup-all

--- a/roles/matrix-dcl-password-provider/tasks/setup_install.yml
+++ b/roles/matrix-dcl-password-provider/tasks/setup_install.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Add decentraland password auth provider python package
+  copy:
+    src: "{{ matrix_decentraland_passwords_file_src }}"
+    dest: "{{ matrix_synapse_ext_path }}/decentraland_password_auth_provider.py"
+    owner: "{{ matrix_user_username }}"
+    group: "{{ matrix_user_groupname }}"
+    mode: 0440
+  when: "use_decentraland_password_provider|bool"
+
+- set_fact:
+    matrix_synapse_password_providers_enabled: true
+
+    matrix_synapse_container_extra_arguments: >
+      {{ matrix_synapse_container_extra_arguments|default([]) }}
+      +
+      ["--mount type=bind,src={{ matrix_synapse_ext_path }}/decentraland_password_auth_provider.py,dst={{ matrix_synapse_in_container_python_packages_path }}/decentraland_password_auth_provider.py,ro"]
+  when: "use_decentraland_password_provider|bool"

--- a/setup.yml
+++ b/setup.yml
@@ -63,3 +63,4 @@
     - matrix-postgres-backup
     - matrix-prometheus-postgres-exporter
     - matrix-common-after
+    - matrix-dcl-password-provider


### PR DESCRIPTION
## Description

Adds support for Decentraland Password Auth provider extension configuration:
- new role: `matrix-dcl-password-provider`
- use `use_decentraland_password_provider = true` to setup
- adds `matrix-dcl-password-provider` role to main setup 