### PR TITLE
chore: add more endpoints to generic workers

### DIFF
--- a/roles/matrix-synapse/vars/workers.yml
+++ b/roles/matrix-synapse/vars/workers.yml
@@ -74,6 +74,19 @@ matrix_synapse_workers_generic_worker_endpoints:
   - ^/_matrix/client/(api/v1|r0|v3|unstable)/join/
   - ^/_matrix/client/(api/v1|r0|v3|unstable)/profile/
 
+  # Device requests
+  - ^/_matrix/client/(r0|v3|unstable)/sendToDevice/
+
+  # Account data requests
+  - ^/_matrix/client/(r0|v3|unstable)/.*/tags
+  - ^/_matrix/client/(r0|v3|unstable)/.*/account_data
+
+  # Receipts requests
+  - ^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt
+  - ^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers
+
+  # Presence requests
+  - ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/
 
   # Additionally, the following REST endpoints can be handled for GET requests:
 


### PR DESCRIPTION
## Description

Following this [documentation](https://matrix-org.github.io/synapse/latest/workers.html#synapseappgeneric_worker), generic workers could handle more endpoints including `presence`, otherwise main process will handle all of them.