### PR TITLE
feat: workers for presence, event persistence and background jobs

### DIFF
--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -1,7 +1,12 @@
 #jinja2: lstrip_blocks: "True"
 
-{% set generic_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'generic_*')|list %}
+
+{% set initial_sync_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'initial-sync-*')|list %}
+{% set sync_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'sync-*')|list %}
+{% set client_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'client-*')|list %}
 {% set presence_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'equalto', 'presence_worker')|list %}
+
+{% set generic_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'generic_*')|list %}
 {% set media_repository_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'media_repository')|list %}
 {% set user_dir_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'user_dir')|list %}
 {% set frontend_proxy_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'frontend_proxy')|list %}
@@ -17,6 +22,55 @@
 		{% endif %}
 
 		{% for worker in generic_workers %}
+			{% if matrix_nginx_proxy_enabled %}
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
+			{% else %}
+				server "127.0.0.1:{{ worker.port }}";
+			{% endif %}
+		{% endfor %}
+	}
+	{% endif %}
+
+	{% if initial_sync_workers %}
+	upstream initial_sync_worker_upstream {
+
+		{% for worker in initial_sync_workers %}
+			{% if matrix_nginx_proxy_enabled %}
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
+			{% else %}
+				server "127.0.0.1:{{ worker.port }}";
+			{% endif %}
+		{% endfor %}
+	}
+	{% endif %}
+
+	{% if sync_workers %}
+	upstream sync_worker_upstream {
+		{% if use_worker_affinity %}
+			# ensures that requests from the same client will always be passed
+			# to the same server (except when this server is unavailable)
+			hash $http_authorization;
+		{% endif %}
+
+		{% for worker in sync_workers %}
+			{% if matrix_nginx_proxy_enabled %}
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
+			{% else %}
+				server "127.0.0.1:{{ worker.port }}";
+			{% endif %}
+		{% endfor %}
+	}
+	{% endif %}
+
+	{% if client_workers %}
+	upstream client_worker_upstream {
+
+		{% if use_worker_affinity %}
+		# ensures that requests from the same client will always be passed
+		# to the same server (except when this server is unavailable)
+		hash $http_authorization;
+		{% endif %}
+		{% for worker in client_workers %}
 			{% if matrix_nginx_proxy_enabled %}
 				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
 			{% else %}
@@ -102,9 +156,154 @@ server {
 			{% endfor %}
 		{% endif %}
 
+		{% if initial_sync_workers and sync_workers %}
+			location ~ ^/_matrix/client/(r0|v3)/sync$ {
+				proxy_set_header Host $host;
+				if ($arg_since) {
+					proxy_pass http://sync_worker_upstream$request_uri;
+				}
+				if ($arg_since = "") {
+					proxy_pass http://initial_sync_worker_upstream$request_uri;
+				}
+			}
+		{% endif %}
+
+		{% if initial_sync_workers %}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/login$ {
+				proxy_pass http://initial_sync_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(r0|v3|unstable)/register$ {
+				proxy_pass http://initial_sync_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/v1/register/m.login.registration_token/validity$ {
+				proxy_pass http://initial_sync_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3)/initialSync$ {
+				proxy_pass http://initial_sync_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3)/rooms/[^/]+/initialSync$ {
+				proxy_pass http://initial_sync_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+		{% endif %}
+
 		{% if presence_workers %}
-			location /_matrix/client/(api/v1|r0|v3|unstable)/presence/ {
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/ {
 				proxy_pass http://presence_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+		{% endif %}
+
+		{% if client_workers %}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/createRoom$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/publicRooms$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/joined_members$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/context/.*$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/members$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/v1/rooms/.*/hierarchy$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/unstable/org.matrix.msc2716/rooms/.*/batch_send$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/unstable/im.nheko.summary/rooms/.*/summary$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(r0|v3|unstable)/account/3pid$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(r0|v3|unstable)/account/whoami$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(r0|v3|unstable)/devices$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/versions$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/voip/turnServer$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/event/ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/joined_rooms$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/search$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			  
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/redact {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/send {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/state/ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/rooms/.*/(join|invite|leave|ban|unban|kick)$ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/join/ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(api/v1|r0|v3|unstable)/profile/ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+
+			location ~ ^/_matrix/client/(r0|v3|unstable)/sendToDevice/ {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+
+			location ~ ^/_matrix/client/(r0|v3|unstable)/.*/tags {
+				proxy_pass http://client_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
+			location ~ ^/_matrix/client/(r0|v3|unstable)/.*/account_data {
+				proxy_pass http://client_worker_upstream$request_uri;
 				proxy_set_header Host $host;
 			}
 		{% endif %}

--- a/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
+++ b/roles/matrix-nginx-proxy/templates/nginx/conf.d/matrix-synapse.conf.j2
@@ -1,6 +1,7 @@
 #jinja2: lstrip_blocks: "True"
 
-{% set generic_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'generic_worker')|list %}
+{% set generic_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'match', 'generic_*')|list %}
+{% set presence_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('instanceId', 'equalto', 'presence_worker')|list %}
 {% set media_repository_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'media_repository')|list %}
 {% set user_dir_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'user_dir')|list %}
 {% set frontend_proxy_workers = matrix_nginx_proxy_synapse_workers_list|selectattr('type', 'equalto', 'frontend_proxy')|list %}
@@ -17,7 +18,7 @@
 
 		{% for worker in generic_workers %}
 			{% if matrix_nginx_proxy_enabled %}
-				server "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.port }}";
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
 			{% else %}
 				server "127.0.0.1:{{ worker.port }}";
 			{% endif %}
@@ -25,11 +26,25 @@
 	}
 	{% endif %}
 
+	{% if presence_workers %}
+	upstream presence_worker_upstream {
+
+		{% for worker in presence_workers %}
+			{% if matrix_nginx_proxy_enabled %}
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
+			{% else %}
+				server "127.0.0.1:{{ worker.port }}";
+			{% endif %}
+		{% endfor %}
+	}
+	{% endif %}
+
+
 	{% if frontend_proxy_workers %}
 	upstream frontend_proxy_upstream {
 		{% for worker in frontend_proxy_workers %}
 			{% if matrix_nginx_proxy_enabled %}
-				server "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.port }}";
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
 			{% else %}
 				server "127.0.0.1:{{ worker.port }}";
 			{% endif %}
@@ -41,7 +56,7 @@
 	upstream media_repository_upstream {
 		{% for worker in media_repository_workers %}
 			{% if matrix_nginx_proxy_enabled %}
-				server "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.port }}";
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
 			{% else %}
 				server "127.0.0.1:{{ worker.port }}";
 			{% endif %}
@@ -53,7 +68,7 @@
 	upstream user_dir_upstream {
 		{% for worker in user_dir_workers %}
 			{% if matrix_nginx_proxy_enabled %}
-				server "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.port }}";
+				server "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.port }}";
 			{% else %}
 				server "127.0.0.1:{{ worker.port }}";
 			{% endif %}
@@ -85,6 +100,13 @@ server {
 				proxy_set_header Host $host;
 			}
 			{% endfor %}
+		{% endif %}
+
+		{% if presence_workers %}
+			location /_matrix/client/(api/v1|r0|v3|unstable)/presence/ {
+				proxy_pass http://presence_worker_upstream$request_uri;
+				proxy_set_header Host $host;
+			}
 		{% endif %}
 
 		{% if media_repository_workers %}
@@ -160,9 +182,9 @@ server {
 	{% if matrix_nginx_proxy_enabled and matrix_nginx_proxy_proxy_synapse_metrics %}
 		{% for worker in matrix_nginx_proxy_proxy_synapse_workers_enabled_list %}
 			{% if worker.metrics_port != 0 %}
-				location /_synapse-worker-{{ worker.type }}-{{ worker.instanceId }}/metrics {
+				location /_synapse-worker-{{ worker.instanceId }}/metrics {
 					resolver 127.0.0.11 valid=5s;
-					set $backend "matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}";
+					set $backend "matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.metrics_port }}";
 					proxy_pass http://$backend/_synapse/metrics;
 					proxy_set_header Host $host;
 

--- a/roles/matrix-nginx-proxy/templates/prometheus/external_prometheus.yml.example.j2
+++ b/roles/matrix-nginx-proxy/templates/prometheus/external_prometheus.yml.example.j2
@@ -1,8 +1,8 @@
 {% for worker in matrix_nginx_proxy_proxy_synapse_workers_enabled_list %}
-  - job_name: '{{ matrix_env }}-synapse-{{ worker.type }}-{{ worker.instanceId }}'
+  - job_name: '{{ matrix_env }}-synapse-{{ worker.instanceId }}'
     scrape_interval: 60s
     scrape_timeout: 60s
-    metrics_path: /_synapse-worker-{{ worker.type }}-{{ worker.instanceId }}/metrics
+    metrics_path: /_synapse-worker-{{ worker.instanceId }}/metrics
 {% if matrix_nginx_proxy_proxy_synapse_metrics_basic_auth_enabled %}
     basic_auth:
       username: prometheus

--- a/roles/matrix-prometheus/templates/prometheus.yml.j2
+++ b/roles/matrix-prometheus/templates/prometheus.yml.j2
@@ -37,7 +37,7 @@ scrape_configs:
         index: 0
   {% for worker in matrix_prometheus_scraper_synapse_workers_enabled_list %}
   {% if worker.metrics_port != 0 %}
-    - targets: ['matrix-synapse-worker-{{ worker.type }}-{{ worker.instanceId }}:{{ worker.metrics_port }}']
+    - targets: ['matrix-synapse-worker-{{ worker.instanceId }}:{{ worker.metrics_port }}']
       labels:
         instance: {{ matrix_domain }}
         job: {{ worker.type }}

--- a/roles/matrix-synapse/tasks/ext/dcl-password-provider/setup_install.yml
+++ b/roles/matrix-synapse/tasks/ext/dcl-password-provider/setup_install.yml
@@ -13,7 +13,5 @@
     matrix_synapse_password_providers_enabled: true
 
     matrix_synapse_container_extra_arguments: >
-      {{ matrix_synapse_container_extra_arguments|default([]) }}
-      +
       ["--mount type=bind,src={{ matrix_synapse_ext_path }}/decentraland_password_auth_provider.py,dst={{ matrix_synapse_in_container_python_packages_path }}/decentraland_password_auth_provider.py,ro"]
   when: "use_decentraland_password_provider|bool"

--- a/roles/matrix-synapse/tasks/synapse/workers/util/inject_systemd_services_for_worker.yml
+++ b/roles/matrix-synapse/tasks/synapse/workers/util/inject_systemd_services_for_worker.yml
@@ -13,7 +13,7 @@
   when: "'instanceId' not in matrix_synapse_worker_details"
 
 - set_fact:
-    matrix_synapse_worker_systemd_service_name: "matrix-synapse-worker-{{ matrix_synapse_worker_details.type }}-{{ matrix_synapse_worker_details.instanceId }}.service"
+    matrix_synapse_worker_systemd_service_name: "matrix-synapse-worker-{{ matrix_synapse_worker_details.instanceId }}.service"
 
 - set_fact:
     matrix_systemd_services_list: "{{ matrix_systemd_services_list + [matrix_synapse_worker_systemd_service_name] }}"

--- a/roles/matrix-synapse/tasks/synapse/workers/util/setup_files_for_worker.yml
+++ b/roles/matrix-synapse/tasks/synapse/workers/util/setup_files_for_worker.yml
@@ -1,7 +1,7 @@
 ---
 
 - set_fact:
-    matrix_synapse_worker_systemd_service_name: "matrix-synapse-worker-{{ matrix_synapse_worker_details.type }}-{{ matrix_synapse_worker_details.instanceId }}"
+    matrix_synapse_worker_systemd_service_name: "matrix-synapse-worker-{{ matrix_synapse_worker_details.instanceId }}"
 
 - set_fact:
     matrix_synapse_worker_container_name: "{{ matrix_synapse_worker_systemd_service_name }}"

--- a/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
+++ b/roles/matrix-synapse/templates/synapse/systemd/matrix-synapse.service.j2
@@ -12,7 +12,7 @@ Wants={{ service }}
 
 {% if matrix_synapse_workers_enabled %}
 {% for matrix_synapse_worker_details in matrix_synapse_workers_enabled_list %}
-Wants=matrix-synapse-worker-{{ matrix_synapse_worker_details.type }}-{{ matrix_synapse_worker_details.port }}.service
+Wants=matrix-synapse-worker-{{ matrix_synapse_worker_details.instanceId }}-{{ matrix_synapse_worker_details.port }}.service
 {% endfor %}
 {% endif %}
 

--- a/roles/matrix-synapse/templates/synapse/worker.yaml.j2
+++ b/roles/matrix-synapse/templates/synapse/worker.yaml.j2
@@ -1,6 +1,6 @@
 #jinja2: lstrip_blocks: "True"
 worker_app: synapse.app.{{ matrix_synapse_worker_details.type }}
-worker_name: {{ matrix_synapse_worker_details.type ~ ':' ~ matrix_synapse_worker_details.port }}
+worker_name: {{ matrix_synapse_worker_details.instanceId }}
 
 {% if matrix_synapse_replication_listener_enabled %}
 worker_replication_host: matrix-synapse
@@ -11,6 +11,12 @@ worker_replication_http_port: {{ matrix_synapse_replication_http_port }}
 
 {% set http_resources = [] %}
 
+{% if matrix_synapse_worker_details.instanceId.startswith('event-persister') %}
+  {% set http_resources = http_resources + ['replication'] %}
+{% else %}
+{% if matrix_synapse_worker_details.instanceId.startswith('presence-worker') %}
+  {% set http_resources = http_resources + ['replication'] %}
+{% endif %}
 {% if matrix_synapse_worker_details.type in ['generic_worker', 'frontend_proxy', 'user_dir'] %}
   {% set http_resources = http_resources + ['client'] %}
 {% endif %}
@@ -20,6 +26,9 @@ worker_replication_http_port: {{ matrix_synapse_replication_http_port }}
 {% if matrix_synapse_worker_details.type in ['media_repository'] %}
   {% set http_resources = http_resources + ['media'] %}
 {% endif %}
+
+{% endif %}
+
 
 {% if http_resources|length > 0 or matrix_synapse_metrics_enabled %}
 worker_listeners:

--- a/roles/matrix-synapse/vars/workers.yml
+++ b/roles/matrix-synapse/vars/workers.yml
@@ -85,9 +85,6 @@ matrix_synapse_workers_generic_worker_endpoints:
   - ^/_matrix/client/(r0|v3|unstable)/rooms/.*/receipt
   - ^/_matrix/client/(r0|v3|unstable)/rooms/.*/read_markers
 
-  # Presence requests
-  - ^/_matrix/client/(api/v1|r0|v3|unstable)/presence/
-
   # Additionally, the following REST endpoints can be handled for GET requests:
 
   # FIXME: ADDITIONAL CONDITIONS REQUIRED: to be enabled manually

--- a/templates/vars.yml.j2
+++ b/templates/vars.yml.j2
@@ -107,11 +107,14 @@ matrix_synapse_database_database: '{{POSTGRES_DATABASE}}'
 {% endif %}
 
 matrix_synapse_workers_enabled_list:
-  - { type: generic_worker, instanceId: 'generic-18111', port: 18111, metrics_port: 19111 }
-  - { type: generic_worker, instanceId: 'generic-18112', port: 18112, metrics_port: 19112 }
-  - { type: generic_worker, instanceId: 'generic-18113', port: 18113, metrics_port: 19113 }
-  - { type: generic_worker, instanceId: 'event-persister1', port: 18114, metrics_port: 19114 }
-  - { type: generic_worker, instanceId: 'event-persister2', port: 18115, metrics_port: 19115 }
+  - { type: generic_worker, instanceId: 'initial-sync-1', port: 18111, metrics_port: 19111 }
+  - { type: generic_worker, instanceId: 'initial-sync-2', port: 18119, metrics_port: 19119 }
+  - { type: generic_worker, instanceId: 'sync-1', port: 18112, metrics_port: 19112 }
+  - { type: generic_worker, instanceId: 'sync-2', port: 18118, metrics_port: 19118 }
+  - { type: generic_worker, instanceId: 'client-1', port: 18113, metrics_port: 19113 }
+  - { type: generic_worker, instanceId: 'client-2', port: 18120, metrics_port: 19120 }
+  - { type: generic_worker, instanceId: 'event-persister-1', port: 18114, metrics_port: 19114 }
+  - { type: generic_worker, instanceId: 'event-persister-2', port: 18115, metrics_port: 19115 }
   - { type: generic_worker, instanceId: 'presence-worker', port: 18116, metrics_port: 19116 }
   - { type: generic_worker, instanceId: 'background-worker', port: 18117, metrics_port: 19117 }
   - { type: pusher, instanceId: 'pusher', port: 0, metrics_port: 19200 }
@@ -127,11 +130,11 @@ matrix_synapse_configuration_extension_yaml: |
       cp_min: 5
       cp_max: 35
   instance_map:
-    event-persister1:
-      host: matrix-synapse-worker-event-persister1
+    event-persister-1:
+      host: matrix-synapse-worker-event-persister-1
       port: 18114
-    event-persister2:
-      host: matrix-synapse-worker-event-persister2
+    event-persister-2:
+      host: matrix-synapse-worker-event-persister-2
       port: 18115
     presence-worker:
       host: matrix-synapse-worker-presence-worker
@@ -141,8 +144,8 @@ matrix_synapse_configuration_extension_yaml: |
       port: 18117
   stream_writers:
     events:
-      - event-persister2
-      - event-persister1
+      - event-persister-2
+      - event-persister-1
     presence: presence-worker
   run_background_tasks_on: background-worker
 
@@ -208,7 +211,7 @@ matrix_mailer_enabled: false
 # at the expense of audio/video calls being unreliable.
 matrix_coturn_enabled: false
 
-matrix_nginx_proxy_proxy_grafana_enabled: false
+matrix_nginx_proxy_proxy_grafana_enabled: true
 
 matrix_nginx_proxy_proxy_synapse_additional_server_configuration_blocks:
   - 'location /_synapse/node-exporter/ {
@@ -217,7 +220,7 @@ matrix_nginx_proxy_proxy_synapse_additional_server_configuration_blocks:
   auth_basic "protected";
   auth_basic_user_file /nginx-data/matrix-synapse-metrics-htpasswd;
   }'
-  
+
 # Isolate matrix homerserver
 matrix_synapse_federation_enabled: false
 

--- a/templates/vars.yml.j2
+++ b/templates/vars.yml.j2
@@ -43,8 +43,6 @@ matrix_synapse_container_client_api_host_bind_port: '127.0.0.1:8008'
 
 matrix_synapse_workers_enabled: true
 
-matrix_synapse_workers_generic_workers_count: {{ GENERIC_WORKERS_COUNT }}
-
 matrix_nginx_proxy_https_enabled: false
 
 
@@ -57,6 +55,7 @@ matrix_synapse_presence_enabled: {{ use_presence }}
 matrix_synapse_enable_registration: true
 {% endif %}
 {% if ENV not in ['prd'] %}
+matrix_synapse_log_level: 'DEBUG'
 # Config to support Romeo and Juliet benchmark and testing tools (429 - too many requests):
 matrix_synapse_rc_registration:
   per_second: 5
@@ -106,12 +105,49 @@ matrix_synapse_database_user: '{{POSTGRES_USER}}'
 matrix_synapse_database_password: '{{POSTGRES_PASSWORD}}'
 matrix_synapse_database_database: '{{POSTGRES_DATABASE}}'
 {% endif %}
+
+matrix_synapse_workers_enabled_list:
+  - { type: generic_worker, instanceId: 'generic-18111', port: 18111, metrics_port: 19111 }
+  - { type: generic_worker, instanceId: 'generic-18112', port: 18112, metrics_port: 19112 }
+  - { type: generic_worker, instanceId: 'generic-18113', port: 18113, metrics_port: 19113 }
+  - { type: generic_worker, instanceId: 'event-persister1', port: 18114, metrics_port: 19114 }
+  - { type: generic_worker, instanceId: 'event-persister2', port: 18115, metrics_port: 19115 }
+  - { type: generic_worker, instanceId: 'presence-worker', port: 18116, metrics_port: 19116 }
+  - { type: generic_worker, instanceId: 'background-worker', port: 18117, metrics_port: 19117 }
+  - { type: pusher, instanceId: 'pusher', port: 0, metrics_port: 19200 }
+  - { type: frontend_proxy, instanceId: 'frontend-proxy', port: 18771, metrics_port: 19200 }
+
 {% set use_decentraland_password_provider = USE_DECENTRALAND_PASSWORD_PROVIDER|default('false') in ['true'] %}
-# Decentraland Password Provider
 use_decentraland_password_provider: {{ use_decentraland_password_provider }}
-{% if use_decentraland_password_provider %}
-# Decentraland password auth provider module
+# Decentraland Password Provider
+
 matrix_synapse_configuration_extension_yaml: |
+  database:
+    args:
+      cp_min: 5
+      cp_max: 35
+  instance_map:
+    event-persister1:
+      host: matrix-synapse-worker-event-persister1
+      port: 18114
+    event-persister2:
+      host: matrix-synapse-worker-event-persister2
+      port: 18115
+    presence-worker:
+      host: matrix-synapse-worker-presence-worker
+      port: 18116
+    background-worker:
+      host: matrix-synapse-worker-background-worker
+      port: 18117
+  stream_writers:
+    events:
+      - event-persister2
+      - event-persister1
+    presence: presence-worker
+  run_background_tasks_on: background-worker
+
+{% if use_decentraland_password_provider %}
+  # Decentraland password auth provider module
   password_providers:
     - module: decentraland_password_auth_provider.DecentralandPasswordAuthProvider
       config:
@@ -181,3 +217,8 @@ matrix_nginx_proxy_proxy_synapse_additional_server_configuration_blocks:
   auth_basic "protected";
   auth_basic_user_file /nginx-data/matrix-synapse-metrics-htpasswd;
   }'
+  
+# Isolate matrix homerserver
+matrix_synapse_federation_enabled: false
+
+# Cache factors per type


### PR DESCRIPTION
## Description

Changes are:
- Specific workers for:
  - Presence
  - Event persistence (2)
  - Background Jobs 
- Federation disabled
- Increase max DB connections 

Other changes related to the worker name are required for internal communication (otherwise there are a few 502 HTTP errors):
- Remove the worker type (i.e. `generic_worker`) since `_` is not a valid char for HTTP comms

### Other notes

We probably want to make some of this to be configurable.